### PR TITLE
improve error messages for .toBeInTheDocument

### DIFF
--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -13,6 +13,15 @@ export function toBeInTheDocument(element) {
   const pass =
     element === null ? false : element.ownerDocument.contains(element)
 
+  const errorFound = () => {
+    return `expected document not to contain element, found ${stringify(
+      element.cloneNode(true),
+    )} instead`
+  }
+  const errorNotFound = () => {
+    return `element could not be found in the document`
+  }
+
   return {
     pass,
     message: () => {
@@ -23,10 +32,7 @@ export function toBeInTheDocument(element) {
           '',
         ),
         '',
-        receivedColor(`${stringify(element.ownerDocument.cloneNode(false))} ${
-          this.isNot ? 'contains:' : 'does not contain:'
-        } ${stringify(element.cloneNode(false))}
-        `),
+        receivedColor(this.isNot ? errorFound() : errorNotFound()),
       ].join('\n')
     },
   }


### PR DESCRIPTION

**What**:

Improve error messages for `.toBeInTheDocument`

**Why**:

The current error was hard to understand

**How**:

Give more context in the error message

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [X] Ready to be merged



---

### Before

`.toBeInTheDocument` 
<img width="626" alt="Screenshot 2019-10-05 at 12 29 08" src="https://user-images.githubusercontent.com/4562878/66253834-369a2000-e76e-11e9-8ad6-fa3ea3f4011a.png">

`not.toBeInTheDocument`
<img width="637" alt="Screenshot 2019-10-05 at 12 28 05" src="https://user-images.githubusercontent.com/4562878/66253845-5fbab080-e76e-11e9-91bd-71e4b3cfbab0.png">

### After

`.toBeInTheDocument` 
<img width="630" alt="Screenshot 2019-10-05 at 12 18 15" src="https://user-images.githubusercontent.com/4562878/66253851-72cd8080-e76e-11e9-8c02-0e2b5bbd12ab.png">

`not.toBeInTheDocument`
<img width="923" alt="Screenshot 2019-10-05 at 12 52 13" src="https://user-images.githubusercontent.com/4562878/66253879-fb4c2100-e76e-11e9-82c0-a3a95ff14261.png">





